### PR TITLE
password hiding in get

### DIFF
--- a/src/main/java/com/fatec/springapi4/entity/user/User.java
+++ b/src/main/java/com/fatec/springapi4/entity/user/User.java
@@ -5,13 +5,15 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonProperty.Access;
 import com.fatec.springapi4.converter.ProfileTypeConverter;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Convert;
 import jakarta.persistence.Entity;
-import jakarta.persistence.EnumType;
-import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -31,7 +33,8 @@ public class User {
     
     @Column(name = "usr_name")
     private String name;
-    
+
+    @JsonProperty(access = Access.WRITE_ONLY)
     @Column(name = "usr_password")
     private String password;
 


### PR DESCRIPTION
# Objetivo:
`Qual o propósito / escopo dessas alterações?`

- resolve #40 
- Ocultar senha do user nas consultas;

# Solução:
`Quais estratégias foram adotadas durante as alterações em questão?`

- Uso de anotação do json. Garantindo que o campo seja ignorado apenas na serialização, mas ainda seja aceito na desserialização. 

