### PR TITLE
fix: `allPartnerReports` pagination

### DIFF
--- a/db/3_postgres_views.sql
+++ b/db/3_postgres_views.sql
@@ -148,7 +148,8 @@ ORDER BY pt_id;
 --PARTNER REPORT
 
 CREATE OR REPLACE VIEW partner_reports AS
-SELECT pt.pt_id,pt.pt_name,tr.tk_name,
+SELECT row_number() OVER (ORDER BY pt.pt_id) AS id,
+		pt.pt_id,pt.pt_name,tr.tk_name,
 		pt_tr.pt_tk_insert_date as tk_start_date,
 		pt_tr.pt_tk_complete_date as tk_end_date,
 		ex.ex_name,
@@ -171,4 +172,4 @@ FROM partner pt
 		ON pt_ql.pt_id = pt_tr.pt_id
 	LEFT JOIN qualifier ql
 		ON ql.ql_id = pt_ql.ql_id
-ORDER BY pt.pt_name;
+ORDER BY pt.pt_id;

--- a/src/main/java/com/fatec/springapi4/controller/PartnerReportsController.java
+++ b/src/main/java/com/fatec/springapi4/controller/PartnerReportsController.java
@@ -1,20 +1,19 @@
 package com.fatec.springapi4.controller;
 
-import java.util.List;
-
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageRequest;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.web.bind.annotation.CrossOrigin;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
-
 import com.fatec.springapi4.entity.PartnerReports;
 import com.fatec.springapi4.repository.PartnerReportsRepository;
 import com.fatec.springapi4.service.IPartnerReportsService;
+import java.util.List;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
+import org.springframework.web.bind.annotation.CrossOrigin;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @CrossOrigin

--- a/src/main/java/com/fatec/springapi4/controller/PartnerReportsController.java
+++ b/src/main/java/com/fatec/springapi4/controller/PartnerReportsController.java
@@ -29,7 +29,7 @@ public class PartnerReportsController {
     @GetMapping
     public Page<PartnerReports> allPartnerReports(@RequestParam(defaultValue = "0") int page,
             @RequestParam(defaultValue = "10") int size) {
-        return partnerReportsRepository.findAll(PageRequest.of(page, size));
+        return partnerReportsRepository.findAll(PageRequest.of(page, size, Sort.by("id")));
     }
 
     @GetMapping
@@ -37,5 +37,4 @@ public class PartnerReportsController {
     public List<PartnerReports> partnerReportsById(@PathVariable("id") Long id) {
         return iPartnerReportsService.listPartnerReportsById(id);
     }
-
 }

--- a/src/main/java/com/fatec/springapi4/entity/PartnerReports.java
+++ b/src/main/java/com/fatec/springapi4/entity/PartnerReports.java
@@ -20,38 +20,38 @@ import lombok.Setter;
 public class PartnerReports {
     @Id
     @Column(name = "pt_id")
-    private Long pt_id;
+    private Long id;
 
     @Column(name = "pt_name")
-    private String pt_name;
+    private String partnerName;
 
     @Column(name = "tk_name")
-    private String tk_name;
+    private String trackName;
 
     @Column(name = "tk_start_date")
-    private LocalDate tk_start_date;
+    private LocalDate trackStartDate;
 
     @Column(name = "tk_end_date")
-    private LocalDate tk_end_date;
+    private LocalDate trackEndDate;
 
     @Column(name = "ex_name")
-    private String ex_name;
+    private String expertiseName;
 
     @Column(name = "ex_start_date")
-    private LocalDate ex_start_date;
+    private LocalDate expertiseStartDate;
 
     @Column(name = "ex_end_date")
-    private LocalDate ex_end_date;
+    private LocalDate expertiseEndDate;
 
     @Column(name = "ql_name")
-    private String ql_name;
+    private String qualifierName;
 
     @Column(name = "ql_start_date")
-    private LocalDate ql_start_date;
+    private LocalDate qualifierStartDate;
 
     @Column(name = "ql_end_date")
-    private LocalDate ql_end_date;
+    private LocalDate qualifierEndDate;
 
     @Column(name = "ql_due_date")
-    private LocalDate ql_due_date;
+    private LocalDate qualifierDueDate;
 }

--- a/src/main/java/com/fatec/springapi4/entity/PartnerReports.java
+++ b/src/main/java/com/fatec/springapi4/entity/PartnerReports.java
@@ -19,8 +19,11 @@ import lombok.Setter;
 @Table(name = "partner_reports")
 public class PartnerReports {
     @Id
-    @Column(name = "pt_id")
+    @Column(name = "id")
     private Long id;
+
+    @Column(name = "pt_id")
+    private Long partnerId;
 
     @Column(name = "pt_name")
     private String partnerName;

--- a/src/main/java/com/fatec/springapi4/repository/PartnerReportsRepository.java
+++ b/src/main/java/com/fatec/springapi4/repository/PartnerReportsRepository.java
@@ -14,7 +14,6 @@ import com.fatec.springapi4.entity.PartnerReports;
 @Repository
 public interface PartnerReportsRepository extends JpaRepository<PartnerReports, Long> {
 
-    @SuppressWarnings("null")
     Page<PartnerReports> findAll(Pageable pageable);
 
     @Query("select p from PartnerReports p where p.id = :id")

--- a/src/main/java/com/fatec/springapi4/repository/PartnerReportsRepository.java
+++ b/src/main/java/com/fatec/springapi4/repository/PartnerReportsRepository.java
@@ -14,6 +14,7 @@ import com.fatec.springapi4.entity.PartnerReports;
 @Repository
 public interface PartnerReportsRepository extends JpaRepository<PartnerReports, Long> {
 
+    @Query("select p from PartnerReports p order by p.id")
     Page<PartnerReports> findAll(Pageable pageable);
 
     @Query("select p from PartnerReports p where p.id = :id")

--- a/src/main/java/com/fatec/springapi4/repository/PartnerReportsRepository.java
+++ b/src/main/java/com/fatec/springapi4/repository/PartnerReportsRepository.java
@@ -17,7 +17,7 @@ public interface PartnerReportsRepository extends JpaRepository<PartnerReports, 
     @SuppressWarnings("null")
     Page<PartnerReports> findAll(Pageable pageable);
 
-    @Query("select p from PartnerReports p where p.pt_id = :id")
+    @Query("select p from PartnerReports p where p.id = :id")
     List<PartnerReports> findByPartnerId(@Param("id") Long id);
 
 }

--- a/src/main/java/com/fatec/springapi4/repository/PartnerRepository.java
+++ b/src/main/java/com/fatec/springapi4/repository/PartnerRepository.java
@@ -12,7 +12,6 @@ import java.util.Optional;
 @Repository
 public interface PartnerRepository extends JpaRepository<Partner, Long> {
 
-    @SuppressWarnings("null")
     Optional<Partner> findById(Long id);
 
     Optional<Partner> findByName(String name);

--- a/src/main/java/com/fatec/springapi4/repository/TrackRepository.java
+++ b/src/main/java/com/fatec/springapi4/repository/TrackRepository.java
@@ -8,7 +8,7 @@ import java.util.Optional;
 
 @Repository
 public interface TrackRepository extends JpaRepository<Track, Long> {
-    @SuppressWarnings("null")
+
     Optional<Track> findById(Long id);
 
     Optional<Track> findByName(String nameTrack);

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -8,3 +8,6 @@ spring.datasource.driver-class-name=org.postgresql.Driver
 
 spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.PostgreSQLDialect
 spring.jpa.hibernate.ddl-auto=none
+
+spring.jpa.show-sql=true
+spring.jpa.properties.hibernate.format_sql=true


### PR DESCRIPTION
# Objetivo:
`Qual o propósito / escopo dessas alterações?`

- Corrigir a paginação do endpoints `allPartnerReports` que estava retornando `size` dados duplicados por página.

# Solução:
`Quais estratégias foram adotadas durante as alterações em questão?`

- Adicionado campo `id` dedicado na view utilizando a função `row_number()` do postgres.
- Adicionado `Sort.by` e `order by` explícitos para garantir que o `id` será utilizado para ordenar os itens retornados na requisição.

extra:
- Atualização dos nomes dos atributos da entidade `PartnerReports` de forma a ficarem mais semânticas, seguindo o padrão estabelecido no resto da codebase;
- Removidas diretivas `@SuppressWarnings("null")` desnecessárias em alguns repositories;
- Configuração para habilitar logs das queries sql no `application.properties`;